### PR TITLE
Fixed deleting DVR images followed by enlarge view

### DIFF
--- a/src/app/DVR.component.html
+++ b/src/app/DVR.component.html
@@ -71,7 +71,7 @@
   </div>
 </div>
 <div class="ui four column grid" *ngIf="cameraDvrFocusArray.length > 0">
-  <div class="column" *ngFor="let cameraPhotos of cameraDvrFocusArray">
+  <div class="column" *ngFor="let cameraPhotos of cameraDvrFocusArray; let i = index;">
     <div class="ui card" >
       <div class="image">
         <img [src]="cameraPhotos.apiUrl" (error)="brokenImg($event)">
@@ -79,10 +79,10 @@
       <div class="content">
         <div class="ui sub header">
           <span class="right floated">{{cameraPhotos.dateString}}</span>
-          <span># {{cameraPhotos.elementNumber + 1}}</span>
+          <span># {{i + 1}}</span>
         </div>
       </div>
-      <div class="extra content" (click)="cardClickAction($event, cameraPhotos)">
+      <div class="extra content" (click)="cardClickAction($event, cameraPhotos, i)">
         <a class="right floated">
           <i class="trash outline small icon"></i> 
           Delete
@@ -99,7 +99,7 @@
     <div class="content">
       <div class="center">
       <img class="ui centered rounded huge image" [src]="cameraDvrFocusArray[enlargedElementVal].apiUrl" (error)="brokenImg($event)" (click)="hideDimmer()">
-      <div class="ui inverted header">{{cameraDvrFocusArray[enlargedElementVal].cameraName}} (Image #{{cameraDvrFocusArray[enlargedElementVal].elementNumber + 1}}) -- {{cameraDvrFocusArray[enlargedElementVal].dateString}}</div>
+      <div class="ui inverted header">{{cameraDvrFocusArray[enlargedElementVal].cameraName}} (Image #{{enlargedElementVal + 1}}) -- {{cameraDvrFocusArray[enlargedElementVal].dateString}}</div>
       <div class="ui inverted">(Click Image to Close)</div>
       </div>
     </div>

--- a/src/app/DVR.component.ts
+++ b/src/app/DVR.component.ts
@@ -14,7 +14,6 @@ declare var $: any;
 
 interface SimpleDvrPhotoElement {                // Holds the selected cameras DVR recordings 
     photoId: number,
-    elementNumber: number,
     cameraName: string,
     apiUrl: string,
     dateString: string
@@ -121,7 +120,7 @@ export class DVRComponent implements OnInit, OnDestroy {
     }
 
     // Checks for the photo click events of Delete or Enlarge
-    cardClickAction(event, sentCameraPhotoInfo) {
+    cardClickAction(event, sentCameraPhotoInfo, indexNumber) {
         let cardClickedOption: string = "";
 
         this.enlargedElementVal = 0;
@@ -132,25 +131,21 @@ export class DVRComponent implements OnInit, OnDestroy {
         }
      
         if (cardClickedOption === "Delete") {
-            this.deleteCameraPicture(sentCameraPhotoInfo);
+            this.deleteCameraPicture(sentCameraPhotoInfo, indexNumber);
         } else if ( cardClickedOption === "Enlarge") {
-            this.enlargedElementVal = sentCameraPhotoInfo.elementNumber;
+            this.enlargedElementVal = indexNumber;
             $('.ui.four.column.grid').dimmer('show');
         }
     }
 
     // Deletes a camera from the Db
-    deleteCameraPicture(sentCameraPhotoInfo) {
+    deleteCameraPicture(sentCameraPhotoInfo, sentIndexNumber) {
 
         this.httpRequestService.deleteCamera(`api/file/${sentCameraPhotoInfo.photoId}`)
         .subscribe(
             data => {
-                
-                // Deletes the photo from the 
-                let deletedPhotoIndex = this.cameraDvrFocusArray.indexOf(sentCameraPhotoInfo);
-                if (deletedPhotoIndex !== -1) {
-                    this.cameraDvrFocusArray.splice(deletedPhotoIndex, 1);
-                }
+                // Deletes the photo from the cameraArray
+                this.cameraDvrFocusArray.splice(sentIndexNumber, 1);
 
                 let cameraElement: LargePhotoElement = null;
                 // Searches for the camera of the deleted photo in the complete photoarray


### PR DESCRIPTION
Deleting a 'middle' DVR image and then Enlarged viewing the last image would break the app. The elementId was removed and replaced with Ang2 ngFor index which gets rid of the need to manually track the elements index.